### PR TITLE
fix: reduce object sizes so they are still inside the u64int limit

### DIFF
--- a/before.json
+++ b/before.json
@@ -1,0 +1,1 @@
+{"PatchOpsPerSec":0,"Add10MBTime":0.23459157020000002,"Add10MBStdev":0.03707814523620726,"DirAddOpsPerSec":0,"DirAddOpsStdev":0,"Cat1MBTime":15.3019408,"Cat1MBStdev":3.9775222434949495,"MkGraphTime":0,"TravGraphTime":0,"TravGraphStdev":0}

--- a/main.go
+++ b/main.go
@@ -151,9 +151,9 @@ func checkTraverseGraph() (float64, float64, float64, error) {
 	base := "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"
 	cur := base
 	log.Println("generating graph...")
-	width := 10
+	width := 2
 	bmkgraph := time.Now()
-	for i := 0; i < 300; i++ {
+	for i := 0; i < 50; i++ {
 		next := base
 		for j := 0; j < width; j++ {
 			n, err := sh.PatchLink(next, fmt.Sprint(j), cur, false)
@@ -169,7 +169,7 @@ func checkTraverseGraph() (float64, float64, float64, error) {
 
 	mkpath := func() string {
 		out := new(bytes.Buffer)
-		for i := 0; i < 290; i++ {
+		for i := 0; i < 40; i++ {
 			fmt.Fprintf(out, "/%d", rand.Intn(width))
 		}
 		return cur + out.String()


### PR DESCRIPTION
Ref
- https://github.com/ipfs/js-ipfs/pull/488#issuecomment-266433052 
- https://github.com/ipfs/go-ipfs/issues/3440